### PR TITLE
Format for proxies during Client configuration

### DIFF
--- a/discum/discum.py
+++ b/discum/discum.py
@@ -55,8 +55,8 @@ class Client:
         self.s.headers.update(self.headers)
         if self.__proxy_host != None: #self.s.proxies defaults to {}
             self.proxies = {
-            'http': self.__proxy_host+':'+self.__proxy_port,
-            'https': self.__proxy_host+':'+self.__proxy_port
+            'http': "http://" +  self.__proxy_host+':'+self.__proxy_port,
+            'https': "http://" +  self.__proxy_host+':'+self.__proxy_port
             }
             self.s.proxies.update(self.proxies)
         if self.log: print("Retrieving Discord's build number...")


### PR DESCRIPTION
Originally, to use proxies I would have to have them formatted like: host = "http://XX.XX.XX.XX" port = "XXXX", which was fine considering I was only using the bot for HTTP-related things. 

However, this format will not work for the gateway connection.  Specifically, the issue is when the socket module calls ```socket.getaddrinfo(host, port)```. I would need to remove the "http://" extension from the proxy to use here. 

I think it's best if the format for the Session proxies defaulted to having the extension already added; it would make cross-compatibility much easier. In any case, all the [examples](https://stackoverflow.com/questions/8287628/proxies-with-python-requests-module) I've seen so far that use proxies with requests have "http://" as their extension.

I'm not sure if others experienced this issue or not, so I'll leave it to you to decide. 