### PR TITLE
Fix typo in http request headers

### DIFF
--- a/discum/discum.py
+++ b/discum/discum.py
@@ -64,7 +64,7 @@ class Client:
 			"Referer": "https://discord.com/channels/@me",
 			"Sec-Fetch-Dest": "empty",
 			"Sec-Fetch-Mode": "cors",
-			"Sec-Fetch_Site": "same-origin",
+			"Sec-Fetch-Site": "same-origin",
 			"Connection": "keep-alive",
 			"Content-Type": "application/json"
 		}


### PR DESCRIPTION
That's supposed to be a `-`, not a `_`. I checked on the web client.