### PR TITLE
Fixed sending Embeds in Docs

### DIFF
--- a/docs/using/REST_Actions.md
+++ b/docs/using/REST_Actions.md
@@ -683,7 +683,7 @@ embed.image('https://cdn.dribbble.com/users/189524/screenshots/2105870/04-exampl
 embed.fields('Hello!',':yum:')
 embed.fields(':smile:','Testing :)')
 embed.author('Tester')
-bot.sendMessage("383006063751856129", embed=embed.read())
+bot.sendMessage("383006063751856129","", embed=embed.read())
 ```
 
 ##### ```sendMessage```


### PR DESCRIPTION
The parameter "message" is not optional, I checked it and a few months ago it was already displayed like this, but some change removed it, making the function not work correctly.