### PR TITLE
Patch Join Guild: 400 Bad request

### DIFF
--- a/discum/guild/guild.py
+++ b/discum/guild/guild.py
@@ -38,7 +38,7 @@ class Guild(object):
 	#just the join guild endpoint, default location mimics joining a guild from the ([+]Add a Server) button
 	def joinGuildRaw(self, inviteCode, guild_id, channel_id, channel_type, location="join guild"):
 		url = self.discord+"invites/"+inviteCode
-		return Wrapper.sendRequest(self.s, 'post', url, headerModifications={"update":{"X-Context-Properties":ContextProperties.get(location, guild_id=guild_id, channel_id=channel_id, channel_type=channel_type)}}, log=self.log)
+		return Wrapper.sendRequest(self.s, 'post', url, "{}", headerModifications={"update":{"X-Context-Properties":ContextProperties.get(location, guild_id=guild_id, channel_id=channel_id, channel_type=channel_type)}}, log=self.log)
 
 	def joinGuild(self, inviteCode, location, wait):
 		guildData = self.getInfoFromInviteCode(inviteCode, with_counts=True, with_expiration=True, fromJoinGuildNav=(location.lower()=="join guild")).json()


### PR DESCRIPTION
Sending joinGuildRaw request with empty cause reject with: 400 Bad Request.

Patch: Send empty JSON object (As done by the client (Mobile))
____________
arandomnewaccount:
hm interesting. Discum's requests are based on the web client. Here's the curl I've copied:
```
curl 'https://discord.com/api/v9/invites/<removed>' \
  -X 'POST' \
  -H 'authority: discord.com' \
  -H 'content-length: 0' \
  -H 'pragma: no-cache' \
  -H 'cache-control: no-cache' \
  -H 'sec-ch-ua: "Chromium";v="92", " Not A;Brand";v="99", "Google Chrome";v="92"' \
  -H 'x-super-properties: <removed>' \
  -H 'x-context-properties: eyJsb2NhdGlvbiI6IkpvaW4gR3VpbGQiLCJsb2NhdGlvbl9ndWlsZF9pZCI6IjxyZW1vdmVkPiIsImxvY2F0aW9uX2NoYW5uZWxfaWQiOiI8cmVtb3ZlZD4iLCJsb2NhdGlvbl9jaGFubmVsX3R5cGUiOjB9' \
  -H 'accept-language: en-US' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'authorization: <removed>' \
  -H 'user-agent: <removed>' \
  -H 'x-fingerprint: <removed>' \
  -H 'accept: */*' \
  -H 'origin: https://discord.com' \
  -H 'sec-fetch-site: same-origin' \
  -H 'sec-fetch-mode: cors' \
  -H 'sec-fetch-dest: empty' \
  -H 'referer: https://discord.com/channels/@me' \
  -H 'cookie: <removed>' \
  --compressed
```
I've replaced some info with ```<removed>```. 
I'm not sure if putting {} in the body will fix this or maybe adding more cookies to discum's requests. 

On the cookie example, discum sets these cookies (dynamically): __dcfduid, __sdcfduid, and locale
However, the web client has __dcfduid, __sdcfduid, _gcl_au, _ga, _gid, _gat_UA-53577205-2, OptanonConsent.

So...that could be another reason. idk. Thx for pointing this out tho - ill leave it open and see what other ppl have experienced.