### PR TITLE
Fix bug in remote access dependences

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ REQUIRED = [
 EXTRAS = {
     'ra': [
         'pycryptodome', 
-        'pyqrcode'
+        'pyqrcode',
         'pypng'
     ]
 }


### PR DESCRIPTION
Don't know why this doesn't raise and error and instead it tries to install "pyqrcodepypng" which is wrong.