### PR TITLE
Add underlined doc for bot.sendMessage

### DIFF
--- a/discum/discum.py
+++ b/discum/discum.py
@@ -321,8 +321,8 @@ class Client:
 		return imports.Messages(self.discord, self.s, self.log).deleteMessage(channelID, messageID)
 
 	#edit message
-	def editMessage(self, channelID, messageID, newMessage):
-		return imports.Messages(self.discord, self.s, self.log).editMessage(channelID, messageID, newMessage)
+	def editMessage(self, channelID, messageID, newMessage="", newEmbed=None):
+		return imports.Messages(self.discord, self.s, self.log).editMessage(channelID, messageID, newMessage, newEmbed)
 
 	#pin message
 	def pinMessage(self, channelID, messageID):

--- a/discum/messages/messages.py
+++ b/discum/messages/messages.py
@@ -254,9 +254,11 @@ class Messages(object):
 		url = self.discord+"channels/"+channelID+"/typing"
 		return Wrapper.sendRequest(self.s, 'post', url, log=self.log)
 
-	def editMessage(self, channelID, messageID, newMessage):
+	def editMessage(self, channelID, messageID, newMessage, newEmbed):
 		url = self.discord+"channels/"+channelID+"/messages/"+messageID
 		body = {"content": newMessage}
+		if newEmbed != None:
+			body["embed"] = newEmbed
 		return Wrapper.sendRequest(self.s, 'patch', url, body, log=self.log)
 
 	def deleteMessage(self, channelID, messageID):

--- a/docs/using/REST_Actions.md
+++ b/docs/using/REST_Actions.md
@@ -1303,6 +1303,7 @@ bot.sendMessage("383003333751856129","Hello You :)")
 - message (str)
     * \*\*bold\*\*
     * \*italicized\*
+    * \_\_underlined\_\_
     * \~\~strikethrough\~\~
     * \>quoted
     * \`code\`


### PR DESCRIPTION
Adds another element to the list of formatting options to include an option for underlined text.