### PR TITLE
Updated User.Py for captcha key support

### DIFF
--- a/discum/user/user.py
+++ b/discum/user/user.py
@@ -204,9 +204,9 @@ class User(object):
 		body = {"password": password}
 		return Wrapper.sendRequest(self.s, 'post', url, body, log=self.log)
 
-	def setPhone(self, number, reason):
+	def setPhone(self, number, reason, captcha_key):
 		url = self.discord+"users/@me/phone"
-		body = {"phone": number, "change_phone_reason": reason}
+		body = {"phone": number, "change_phone_reason": reason, "captcha_key": captcha_key}
 		return Wrapper.sendRequest(self.s, 'post', url, body, log=self.log)
 
 	def validatePhone(self, number, code, password):


### PR DESCRIPTION
Thr captcha key is needed since a new discord update.
Captcha key is passed by arg "captcha_key"
Captcha key can be obtained by using services like 2captcha or capmonster
_______
arandomnewaccount:
a neater solution might be to put the captcha support inside https://github.com/Merubokkusu/Discord-S.C.U.M/blob/master/discum/RESTapiwrap.py and have it retry the request (but use the captcha key) whenever needed

If done like this, all reqs that could potentially need captcha can use captcha. 