### PR TITLE
Fix #339

### DIFF
--- a/discum/logger.py
+++ b/discum/logger.py
@@ -9,7 +9,9 @@ class LogLevel:
 
 class Logger:
 	@staticmethod
-	def log(text, color=None, log={"console":True, "file":False}):
+	def log(text, color=None, log={"console":True, "file":False, "encoding":"utf-8"}):
+		if "encoding" not in log:
+			log["encoding"] = "utf-8"
 		if isinstance(log, bool):
 			log = {"console":log, "file":False}
 		if log["console"]:
@@ -19,5 +21,10 @@ class Logger:
 				string = text
 			print(string)
 		if log["file"]:
-			with open(log["file"], 'a+') as f:
-				f.write(text + '\n\n')
+			with open(log["file"], 'a+', encoding=log["encoding"]) as f:
+				try:
+					f.write(text + '\n\n')
+				except UnicodeEncodeError:
+					print("Error: Failed to write unicode characters to log. You may need to change your log encoding to utf-8.")
+				except Exception as e:
+					print("Failed to write to log! Error: {} You may need to change your log encoding to utf-8.".format(e))

--- a/docs/using/General.md
+++ b/docs/using/General.md
@@ -22,25 +22,25 @@
 ## Variables
 
 ### logging
-```bot.log``` dict, manages logging for REST actions      
+```bot.log``` dict, manages logging for REST actions. "encoding" is optional and defaults to 'utf-8'.
 ```python
 bot.log = {"console":True, "file":False}
 #or
-bot.log = {"console":False, "file":"log.txt"}
+bot.log = {"console":False, "file":"log.txt", "encoding":"utf-8"}
 #etc...
 ```
 ```bot.gateway.log``` dict, manages logging for gateway actions (live events, websocket)
 ```python
 bot.gateway.log = {"console":True, "file":False}
 #or
-bot.gateway.log = {"console":False, "file":"gatewaylog.txt"}
+bot.gateway.log = {"console":False, "file":"gatewaylog.txt", "encoding":"utf-8"}
 #etc...
 ```
 ```bot.ra.log``` dict, manages logging for remote authentication gateway actions (login thru qr-code)
 ```python
 bot.ra.log = {"console":True, "file":False}
 #or
-bot.ra.log = {"console":False, "file":"ralog.txt"}
+bot.ra.log = {"console":False, "file":"ralog.txt", "encoding":"utf-8"}
 #etc...
 ```
 

--- a/docs/using/Get_Started.md
+++ b/docs/using/Get_Started.md
@@ -42,7 +42,7 @@ bot = discum.Client(token="user token here")
 -   **user\_agent** (Optional[str/list]) - defaults to "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36". Input a list of user agent strings to randomly pick a user agent
 -   **locale** (Optional[str]) - defaults to "en-US"
 -   **build\_num** (Optional[int]) - defaults to "request", which then requests the discord build number
--   **log** (Optional[dict]) - defaults to {"console":True, "file":False}. The value of "file" can be set to a filename (which is created if it does not exist)
+-   **log** (Optional[dict]) - defaults to {"console":True, "file":False, "encoding":"utf-8"}. The value of "file" can be set to a filename (which is created if it does not exist). The encoding can be specified manually, but setting it to anything other than utf-8 may cause UnicodeEncodeErrors.
 
 ### Returns:
 


### PR DESCRIPTION
The default encoding used in f.write on Windows is ANSI, which silently throws an error if you try to write unicode characters, meaning that if unicode characters are incoded in an event and file logging is enabled, the event is silently ignored.
Fixes the issue by making the encoding a logger option, defaulting to utf-8. Also adds error handling so even if a write file error occurs the event is still handled.