### PR TITLE
Add missing channel / msg types

### DIFF
--- a/discum/gateway/types.py
+++ b/discum/gateway/types.py
@@ -25,7 +25,8 @@ class Types:
 		20: "application_command",
 		21: "thread_starter_message",
 		22: "guild_invite_reminder",
-		23: "context_menu_command"
+		23: "context_menu_command",
+		24: "auto_moderation_action"
 	}
 
 	channelTypes = {
@@ -39,7 +40,9 @@ class Types:
 		10: "guild_news_thread",
 		11: "guild_public_thread",
 		12: "guild_private_thread",
-		13: "guild_stage_voice"
+		13: "guild_stage_voice",
+		14: "guild_directory",
+		15: "guild_form"
 	}
 
 	relationshipTypes = {


### PR DESCRIPTION
This PR resolves issues #409 #407 #376 #383 #344 

When interacting with servers that contain the new unrecognized channel types or message types, parsing fails silently. This can cause unexpected behavior including causing `settings_ready` to be empty

Example: If an user is a member of a guild that contains an unrecognized channel type, the StartParse will throw. This is being caught silently somewhere and you end up with an empty settings_ready object. 
_______________
arandomnewaccount:
The issues you mentioned are unrelated. Iirc, those issues have to do with the client not receiving the READY message. 
This pr did still update the message parsing so thx.
